### PR TITLE
Ensure that custom field variable names have a '_' where the display name had spaces

### DIFF
--- a/paystack/src/main/java/co/paystack/android/model/Charge.java
+++ b/paystack/src/main/java/co/paystack/android/model/Charge.java
@@ -167,7 +167,7 @@ public class Charge extends PaystackModel {
         JSONObject customObj = new JSONObject();
         customObj.put("value", value);
         customObj.put("display_name", displayName);
-        customObj.put("variable_name", displayName.toLowerCase(Locale.getDefault()).replaceAll("[^a-z0-9 ]","_"));
+        customObj.put("variable_name", displayName.toLowerCase(Locale.getDefault()).replaceAll("[^a-z0-9]","_"));
         this.custom_fields.put(customObj);
         this.hasMeta = true;
         return this;


### PR DESCRIPTION
Fixes the issue where custom field variable names have a space

## Changes made by this pull request
- remove spaces from the characters whitelisted for variable names
