### PR TITLE
Setup Consumer Proguard Files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,5 +30,5 @@ ext {
 
     buildToolsVersion = "29.0.2"
     supportLibraryVersion = "28.0.0"
-    versionName = "3.0.18"
+    versionName = "3.0.19-dev"
 }

--- a/paystack/build.gradle
+++ b/paystack/build.gradle
@@ -12,14 +12,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     compileOptions {

--- a/paystack/proguard-rules.pro
+++ b/paystack/proguard-rules.pro
@@ -1,17 +1,1 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/segunfamisa/Documents/Softwares/adt-bundle-mac-x86_64-20130729/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keepclassmembers class co.paystack.android.api.model.** { <fields>; }

--- a/paystack/src/main/java/co/paystack/android/api/model/TransactionApiResponse.java
+++ b/paystack/src/main/java/co/paystack/android/api/model/TransactionApiResponse.java
@@ -35,7 +35,10 @@ public class TransactionApiResponse extends ApiResponse implements Serializable 
         try {
             return new Gson().fromJson(jsonString, TransactionApiResponse.class);
         } catch (Exception e) {
-            return TransactionApiResponse.unknownServerResponse();
+            TransactionApiResponse t = new TransactionApiResponse();
+            t.status = "0";
+            t.message = e.getMessage();
+            return t;
         }
     }
 


### PR DESCRIPTION
Fixes an issue where parsing charge responses caused a crash because of Proguard obfuscation.

## Changes made by this pull request
- Setup a consumer proguard file
- Return a more descriptive error when parsing an API response fails.