### PR TITLE
Fix crash that occurs when PIN authentication is required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ ext {
 
     buildToolsVersion = "29.0.2"
     supportLibraryVersion = "28.0.0"
-    versionName = "3.1.1"
+    versionName = "3.1.2"
 }

--- a/paystack/src/main/java/co/paystack/android/TransactionManager.java
+++ b/paystack/src/main/java/co/paystack/android/TransactionManager.java
@@ -195,7 +195,7 @@ class TransactionManager {
             return;
         }
 
-        if (transactionApiResponse.status.equalsIgnoreCase("2") && transactionApiResponse.auth.equalsIgnoreCase("avs")) {
+        if (transactionApiResponse.status.equalsIgnoreCase("2") && transactionApiResponse.hasValidAuth() && transactionApiResponse.auth.equalsIgnoreCase("avs")) {
             new AddressVerificationAsyncTask().execute(transactionApiResponse.avsCountryCode);
             return;
         }


### PR DESCRIPTION
## Changes made by this pull request
- Fixes a NullPointerException that occurs when response status `2` is returned without an `auth` value attached.
This fix makes sure the SDK goes on to prompt the user for their PIN