### PR TITLE
Update to AndroidX from support lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,5 @@ ext {
     versionCode = 18
 
     buildToolsVersion = "29.0.2"
-    supportLibraryVersion = "28.0.0"
     versionName = "3.1.2"
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.assertj:assertj-core:3.12.2'

--- a/example/src/main/java/co/paystack/example/MainActivity.java
+++ b/example/src/main/java/co/paystack/example/MainActivity.java
@@ -3,13 +3,14 @@ package co.paystack.example;
 import android.app.ProgressDialog;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import org.json.JSONException;
 

--- a/example/src/main/res/values/styles.xml
+++ b/example/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light">
+    <style name="AppTheme" parent="@style/Theme.AppCompat.Light">
         <!-- Customize your theme here. -->
     </style>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,10 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# This is neccessary because we use 'co.paystack.android.design.widget:pinpad:1.0.4'
+# Once pinpad has been updated (https://github.com/PaystackHQ/library-android-pinpad/pull/6)
+# Then android.enableJetifier=true can be deleted and full AndroidX migration is complete
+android.enableJetifier=true  
+
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,6 @@
 # This is neccessary because we use 'co.paystack.android.design.widget:pinpad:1.0.4'
 # Once pinpad has been updated (https://github.com/PaystackHQ/library-android-pinpad/pull/6)
 # Then android.enableJetifier=true can be deleted and full AndroidX migration is complete
-android.enableJetifier=true  
+android.enableJetifier=true
 
 android.useAndroidX=true

--- a/paystack/build.gradle
+++ b/paystack/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
     implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'co.paystack.android.design.widget:pinpad:1.0.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7"

--- a/paystack/src/main/java/co/paystack/android/ui/AddressVerificationActivity.kt
+++ b/paystack/src/main/java/co/paystack/android/ui/AddressVerificationActivity.kt
@@ -1,14 +1,13 @@
 package co.paystack.android.ui
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.ListPopupWindow
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
 import co.paystack.android.R
 import co.paystack.android.mobilemoney.data.api.PaystackApiFactory
 import co.paystack.android.model.AvsState
@@ -99,7 +98,7 @@ class AddressVerificationActivity : AppCompatActivity(), CoroutineScope {
 
     private fun validateForm() {
         val isValid = etStreet.text.isNotBlank() && etCity.text.toString().isNotBlank() &&
-            etZipCode.text.toString().isNotBlank() && selectedState != null
+                etZipCode.text.toString().isNotBlank() && selectedState != null
 
         btnConfirm.isEnabled = isValid
     }

--- a/paystack/src/main/java/co/paystack/android/ui/CardActivity.java
+++ b/paystack/src/main/java/co/paystack/android/ui/CardActivity.java
@@ -1,13 +1,14 @@
 package co.paystack.android.ui;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import co.paystack.android.R;
 import co.paystack.android.model.Card;

--- a/paystack/src/main/java/co/paystack/android/ui/PinActivity.java
+++ b/paystack/src/main/java/co/paystack/android/ui/PinActivity.java
@@ -1,8 +1,9 @@
 package co.paystack.android.ui;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.WindowManager;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import co.paystack.android.R;
 import co.paystack.android.design.widget.PinPadView;
@@ -51,8 +52,6 @@ public class PinActivity extends AppCompatActivity {
         super.onDestroy();
         handleSubmit("");
     }
-
-
 
 
 }

--- a/paystack/src/main/res/values/styles.xml
+++ b/paystack/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Paystack.Dialog" parent="Theme.AppCompat">
+    <style name="Paystack.Dialog" parent="@style/Theme.AppCompat">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>


### PR DESCRIPTION
https://developer.android.com/jetpack/androidx/migrate

Fixes #117 

- no change of behaviour
- formatted as I went

At the moment it has to use `enableJetifier=true` once this PR is merged and released: https://github.com/PaystackHQ/library-android-pinpad/pull/6 this library can depend on the AndroidX version of PinPad and enableJetifier can be removed.

Any questions let me know

