### PR TITLE
Pass Device ID to BaseRequestBody via a constructor call.

### DIFF
--- a/paystack/src/main/java/co/paystack/android/TransactionManager.java
+++ b/paystack/src/main/java/co/paystack/android/TransactionManager.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.CountDownTimer;
+import android.provider.Settings;
 import android.util.Log;
 
 import java.security.KeyManagementException;
@@ -83,8 +84,9 @@ class TransactionManager {
             throw new ProcessingException();
         }
         setProcessingOn();
-        chargeRequestBody = new ChargeRequestBody(charge);
-        validateRequestBody = new ValidateRequestBody();
+        String deviceId = "androidsdk_" + Settings.Secure.getString(activity.getContentResolver(), Settings.Secure.ANDROID_ID);
+        chargeRequestBody = new ChargeRequestBody(charge, deviceId);
+        validateRequestBody = new ValidateRequestBody(deviceId);
     }
 
     void chargeCard(Activity activity, Charge charge, Paystack.TransactionCallback transactionCallback) {

--- a/paystack/src/main/java/co/paystack/android/api/request/BaseRequestBody.java
+++ b/paystack/src/main/java/co/paystack/android/api/request/BaseRequestBody.java
@@ -1,12 +1,8 @@
 package co.paystack.android.api.request;
 
-import android.provider.Settings;
-
 import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
-
-import co.paystack.android.PaystackSdk;
 
 /**
  * A base for all request bodies
@@ -18,9 +14,9 @@ abstract class BaseRequestBody {
 
     public abstract HashMap<String, String> getParamsHashMap();
 
-    void setDeviceId() {
-        this.device = "androidsdk_" + Settings.Secure.getString(PaystackSdk.applicationContext.getContentResolver(),
-                Settings.Secure.ANDROID_ID);
+    protected BaseRequestBody(String deviceId) {
+        this.device = deviceId;
     }
+
 
 }

--- a/paystack/src/main/java/co/paystack/android/api/request/ChargeRequestBody.java
+++ b/paystack/src/main/java/co/paystack/android/api/request/ChargeRequestBody.java
@@ -72,8 +72,8 @@ public class ChargeRequestBody extends BaseRequestBody {
     private String plan;
     private HashMap<String, String> additionalParameters;
 
-    public ChargeRequestBody(Charge charge) {
-        this.setDeviceId();
+    public ChargeRequestBody(Charge charge, String deviceId) {
+        super(deviceId);
         this.clientData = Crypto.encrypt(StringUtils.concatenateCardFields(charge.getCard()));
         this.last4 = charge.getCard().getLast4digits();
         this.public_key = PaystackSdk.getPublicKey();

--- a/paystack/src/main/java/co/paystack/android/api/request/ValidateRequestBody.java
+++ b/paystack/src/main/java/co/paystack/android/api/request/ValidateRequestBody.java
@@ -16,8 +16,8 @@ public class ValidateRequestBody extends BaseRequestBody implements Serializable
     @SerializedName(FIELD_TOKEN)
     private String token;
 
-    public ValidateRequestBody() {
-        this.setDeviceId();
+    public ValidateRequestBody(String deviceId) {
+        super(deviceId);
     }
 
     private String getTrans() {


### PR DESCRIPTION
Signed-off-by: Michael obi <michael@paystack.com>

## Changes made by this pull request
- Set device ID string in constructors of RequestBody classes to make it easier to test `TransactionManager`

