### PR TITLE
Run testDebug builds in place of test in CI

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -32,5 +32,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build test sonarqube --scan
+        run: ./gradlew build testDebug sonarqube --scan
         


### PR DESCRIPTION
Running `gradlew testDebug` allows access to classes in the debug source set

