### PR TITLE
Fixes an issue where Jacoco test coverage doesn't get generated.

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -32,5 +32,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew testDebug sonarqube --scan
+        run: ./gradlew JacocoTestReport sonarqube --scan
         

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -12,7 +12,7 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
 
     reports {
         xml.enabled = true

--- a/paystack/build.gradle
+++ b/paystack/build.gradle
@@ -11,7 +11,7 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
 
     reports {
         xml.enabled = true


### PR DESCRIPTION
- Removes `testDebug` task from CI because `JacocoTestReport` now depends on and runs `testDebugUnitTest`

